### PR TITLE
Gracefully handle invalid paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function isType(fsStatType, statsMethodName, filePath) {
 		const stats = await fsPromises[fsStatType](filePath);
 		return stats[statsMethodName]();
 	} catch (error) {
-		if (error.code === 'ENOENT') {
+		if (error.code === 'ENOENT' || error.code === 'ERR_INVALID_ARG_VALUE') {
 			return false;
 		}
 
@@ -25,7 +25,7 @@ function isTypeSync(fsStatType, statsMethodName, filePath) {
 	try {
 		return fs[fsStatType](filePath)[statsMethodName]();
 	} catch (error) {
-		if (error.code === 'ENOENT') {
+		if (error.code === 'ENOENT' || error.code === 'ERR_INVALID_ARG_VALUE') {
 			return false;
 		}
 
@@ -38,4 +38,8 @@ export const isDirectory = isType.bind(null, 'stat', 'isDirectory');
 export const isSymlink = isType.bind(null, 'lstat', 'isSymbolicLink');
 export const isFileSync = isTypeSync.bind(null, 'statSync', 'isFile');
 export const isDirectorySync = isTypeSync.bind(null, 'statSync', 'isDirectory');
-export const isSymlinkSync = isTypeSync.bind(null, 'lstatSync', 'isSymbolicLink');
+export const isSymlinkSync = isTypeSync.bind(
+	null,
+	'lstatSync',
+	'isSymbolicLink'
+);

--- a/test/nominal.js
+++ b/test/nominal.js
@@ -1,5 +1,12 @@
 import test from 'ava';
-import {isDirectory, isDirectorySync, isFile, isFileSync, isSymlink, isSymlinkSync} from '../index.js';
+import {
+	isDirectory,
+	isDirectorySync,
+	isFile,
+	isFileSync,
+	isSymlink,
+	isSymlinkSync
+} from '../index.js';
 
 test('.file()', async t => {
 	t.true(await isFile('package.json'));
@@ -38,6 +45,14 @@ test('return false if path doesn\'t exist - async', async t => {
 
 test('return false if path doesn\'t exist - sync', t => {
 	t.false(isFileSync('unicorn'));
+});
+
+test('return false if path is invalid - async', async t => {
+	t.false(await isFile('/\u0000path.txt'));
+});
+
+test('return false if path is invalid - sync', t => {
+	t.false(isFileSync('/\u0000path.txt'));
 });
 
 test('throws invalid argument - async', async t => {


### PR DESCRIPTION
This adds graceful handling of invalid paths. 

I think `false` is the correct response rather than throwing as the file is not of that type if it cannot be read.

Context: 

This is affecting Vite due to their use of virtual modules, which they signify by using `\0` in the path.

```
[vite:react-babel] dp-ideal/commonjsHelpers.js: The argument 'path' must be a string or Uint8Array without null bytes. Received 'dp-ideal/\x00commonjsHelpers.js'
file: commonjsHelpers.js
error during build:
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string or Uint8Array without null bytes. Received 'dp-ideal/\x00commonjsHelpers.js'
    at Object.statSync (fs.js:1124:10)
    at isTypeSync (dp-ideal/node_modules/path-type/index.js:28:24)
    at getDirectorySync (dp-ideal/node_modules/cosmiconfig/dist/getDirectory.js:28:61)
    at ExplorerSync.searchSync (dp-ideal/node_modules/cosmiconfig/dist/ExplorerSync.js:26:63)
    at getConfigFromFile (dp-ideal/node_modules/babel-plugin-macros/dist/index.js:256:40)
    at getConfig (dp-ideal/node_modules/babel-plugin-macros/dist/index.js:294:24)
    at applyMacros (dp-ideal/node_modules/babel-plugin-macros/dist/index.js:210:18)
    at ImportDeclaration (dp-ideal/node_modules/babel-plugin-macros/dist/index.js:110:28)
    at NodePath._call (dp-ideal/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (dp-ideal/node_modules/@babel/traverse/lib/path/context.js:40:17)
```