### PR TITLE
Use "node:fs" instead of "fs" 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,23 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 16
+          - 16.0.0
           - 14
-          - 12
+          - 14.18.0
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
+        exclude:
+          # Node 14 is not available on macos anymore
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 14.18.0
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import fs, {promises as fsPromises} from 'fs';
+import fs, {promises as fsPromises} from 'node:fs';
 
 async function isType(fsStatType, statsMethodName, filePath) {
 	if (typeof filePath !== 'string') {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=14.18.0 <15 || >=16"
 	},
 	"scripts": {
 		"test": "xo && nyc ava && tsd"
@@ -39,9 +39,10 @@
 		"filesystem"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"nyc": "^15.1.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.37.1"
+		"ava": "^5.3.1",
+		"nyc": "^17.0.0",
+		"tsd": "^0.31.1",
+		"xo": "^0.40.0",
+		"@types/node": "<18.14.1"
 	}
 }

--- a/test/eacces.js
+++ b/test/eacces.js
@@ -1,4 +1,4 @@
-import fs, {promises as fsPromises} from 'fs';
+import fs, {promises as fsPromises} from 'node:fs';
 import test from 'ava';
 import {isFile, isFileSync} from '../index.js';
 


### PR DESCRIPTION
And bump the minimum Nodejs version to the versions that support this feature.

Dev dependencies are also bumped to the newest ones that can run on said minimal nodejs versions and do not require further changes to the code or tests.

Also added Windows to the CI tests and updated `actions/setup-node` to `v4`. Excluded Node 14 from MacOS, as those binaries are not available anymore.

---

This improves compatibility with runtimes other than nodejs (`workerd` in particular is known to only provide node compatibility layer for "node:" prefixed modules) at the cost of leaving behind older nodejs versions.